### PR TITLE
Add sleep-on-idle option to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -77,5 +77,6 @@ exec docker run --rm --name qwen38-sglang-run --gpus all \
     --num-continuous-decode-steps 2 \
     --reasoning-parser qwen3 --tool-call-parser qwen3_coder \
     --chat-template /out/chat-template-sglang.jinja \
+    --sleep-on-idle \
     --api-key "$KEY" \
     --host 0.0.0.0 --port "$PORT"


### PR DESCRIPTION
Adding --sleep-on-idle \ parameter to SGLang, because of reports of high power usage as a result of high CPU usage when idle.